### PR TITLE
Add support for alternate output formats

### DIFF
--- a/ClassNameDeobfuscator.py
+++ b/ClassNameDeobfuscator.py
@@ -75,10 +75,10 @@ class ClassNameDeobfuscator():
         self.out(' [*] Deobfuscating class names from namespace {0}...'.format(self.path_to_namespace(namespace_dir)))
         for dirpath, dirnames, filenames in os.walk(namespace_dir):
             namespace = self.path_to_namespace(dirpath)
-            for file in filenames:
-                if file.endswith('smali'):
-                    deobfuscated_name = self.deobfuscate_smali_file_class(dirpath, file)
-                    message = self.format_message(file, deobfuscated_name)
+            for filename in filenames:
+                if filename.endswith('smali'):
+                    deobfuscated_name = self.deobfuscate_smali_file_class(dirpath, filename)
+                    message = self.format_message(filename, deobfuscated_name)
                     self.out(message)
 
     def execute(self):


### PR DESCRIPTION
Closes #1

Add support for alternate output methods. Initial support is for a format that makes bulk file renaming easier. This output format can be invoked with the command line argument `-f bulk`.

Instead of outputting,

`com.someApp.a.smali => com.someApp.TurtleWriter.smali`

`-f bulk` will format output like:

`a.smail|TurtleWriter.smali`
